### PR TITLE
Fixed nested <ul> margin and increase padding-left

### DIFF
--- a/less/content.less
+++ b/less/content.less
@@ -12,8 +12,10 @@ ul:not(.blocks-gallery-grid) {
 	padding: 0 0 0 0.9em;
 	line-height: var(--line-height-default);
 
+	// Nesting:
 	ul {
-		padding: 0 0 0 0.9em;
+		padding: 0 0 0 1.5em;
+		margin: 0;
 	}
 }
 

--- a/less/meta.less
+++ b/less/meta.less
@@ -6,7 +6,7 @@
   Author: Sebastian Herrmann
   Author URI: https://herrherrmann.net
   Tags: two-columns, left-sidebar, custom-menu, custom-header, editor-style
-  Version: 1.1.0
+  Version: 1.1.1
   License: MIT License
   License URI: http://opensource.org/licenses/MIT
 */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "silver-ratio",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "A simple WordPress theme.",
 	"main": "gulpfile.js",
 	"scripts": {


### PR DESCRIPTION
Removes the unneeded/accidental bottom margins of nested `<ul>` elements. Also increased the padding-left a bit to make the nesting clearer.