### PR TITLE
Add underlines to links in content and improve link styles in general

### DIFF
--- a/less/basic-html.less
+++ b/less/basic-html.less
@@ -78,20 +78,22 @@ h6 {
 }
 
 a {
-	font-weight: var(--font-weight-bold);
+	font-weight: var(--font-weight-normal);
 	word-break: break-word;
 
 	&,
 	&:visited,
 	&:link {
 		color: var(--accent-color);
-		text-decoration: none;
+		text-decoration: underline;
+		text-decoration-color: var(--text-color-lighter);
+		text-underline-offset: .15em;
 	}
 
 	&:active,
 	&:hover {
-		color: var(--accent-color-dark);
-		text-decoration: none;
+		text-decoration: underline;
+		text-decoration-color: var(--accent-color);
 	}
 }
 

--- a/less/content.less
+++ b/less/content.less
@@ -128,6 +128,7 @@ iframe {
 		a {
 			color: var(--text-color);
 			font-weight: var(--font-weight-normal);
+			text-decoration: none;
 
 			&:hover {
 				color: var(--text-color-dark);
@@ -148,6 +149,7 @@ iframe {
 		.tags {
 			a {
 				display: inline-block;
+				text-decoration: none;
 				white-space: nowrap;
 				font-weight: var(--font-weight-normal);
 				padding: .2em .8em;

--- a/less/footer.less
+++ b/less/footer.less
@@ -30,9 +30,9 @@
 			a {
 				color: var(--footer-text-color);
 				font-weight: var(--font-weight-normal);
+				text-decoration: none;
 
 				&:hover {
-					color: var(--footer-text-color);
 					text-decoration: underline;
 				}
 			}

--- a/less/header.less
+++ b/less/header.less
@@ -15,10 +15,10 @@
 		font-size: var(--font-size-title);
 		font-weight: var(--font-weight-normal);
 		color: var(--text-color);
+		text-decoration: none;
 
 		&:hover {
 			color: var(--accent-color);
-			text-decoration: none;
 		}
 
 		@media (min-width: @breakpoint-desktop) {
@@ -58,6 +58,7 @@
 				color: var(--text-color);
 				font-weight: var(--font-weight-bold);
 				margin-right: .5em;
+				text-decoration: none;
 
 				&:hover {
 					color: var(--text-color-dark);

--- a/less/meta.less
+++ b/less/meta.less
@@ -6,7 +6,7 @@
   Author: Sebastian Herrmann
   Author URI: https://herrherrmann.net
   Tags: two-columns, left-sidebar, custom-menu, custom-header, editor-style
-  Version: 1.3.1
+  Version: 1.4.0
   License: MIT License
   License URI: https://opensource.org/license/mit/
 */

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -6,6 +6,7 @@
 	padding: .3em .8em;
 	color: var(--accent-color);
 	font-weight: var(--font-weight-normal);
+	text-decoration: none;
 
 	&:hover {
 		background-color: var(--light-color-dark);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "silver-ratio",
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "silver-ratio",
-			"version": "1.3.1",
+			"version": "1.4.0",
 			"license": "ISC",
 			"devDependencies": {
 				"@babel/cli": "7.19.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "silver-ratio",
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"description": "A simple WordPress theme.",
 	"main": "gulpfile.js",
 	"scripts": {


### PR DESCRIPTION
Improve the link styles, by adding an underline to all links within the content. #a11y

### Before
![Bildschirmfoto 2023-05-18 um 14 06 15](https://github.com/herrherrmann/silver-ratio/assets/6429568/2a15672c-f0ca-40ea-9e2d-eecc247d8efe)

### After
![Bildschirmfoto 2023-05-18 um 14 05 42](https://github.com/herrherrmann/silver-ratio/assets/6429568/286d62d8-4c98-4963-93cf-7201bb503966)
