### PR TITLE
Make text underline color in menu consistent in Safari

### DIFF
--- a/less/basic-html.less
+++ b/less/basic-html.less
@@ -1,6 +1,6 @@
 html,
 body {
-	font-family: 'Chivo', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+	font-family: @font-family-regular;
 	font-size: var(--font-size-regular);
 	font-weight: var(--font-weight-normal);
 	line-height: var(--line-height-default);
@@ -41,7 +41,7 @@ h4,
 h5,
 h6 {
 	&, & a {
-		font-family: 'Cantata One', serif;
+		font-family: @font-family-titles;
 		font-weight: var(--font-weight-normal);
 		line-height: var(--line-height-small);
 	}

--- a/less/content.less
+++ b/less/content.less
@@ -185,7 +185,7 @@ form {
 	textarea {
 		padding: .65em .8em;
 		max-width: 100%;
-		font-family: 'Chivo', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+		font-family: @font-family-regular;
 		font-size: var(--font-size-regular);
 		font-weight: var(--font-weight-normal);
 		line-height: var(--line-height-small);

--- a/less/header.less
+++ b/less/header.less
@@ -11,7 +11,7 @@
 	}
 
 	a {
-		font-family: 'Cantata One', serif;
+		font-family: @font-family-titles;
 		font-size: var(--font-size-title);
 		font-weight: var(--font-weight-normal);
 		color: var(--text-color);

--- a/less/header.less
+++ b/less/header.less
@@ -73,6 +73,7 @@
 				a {
 					color: var(--accent-color);
 					text-decoration: underline;
+					text-decoration-color: var(--accent-color);
 					text-underline-offset: .1em;
 				}
 			}

--- a/less/meta.less
+++ b/less/meta.less
@@ -6,7 +6,7 @@
   Author: Sebastian Herrmann
   Author URI: https://herrherrmann.net
   Tags: two-columns, left-sidebar, custom-menu, custom-header, editor-style
-  Version: 1.4.0
+  Version: 1.4.2
   License: MIT License
   License URI: https://opensource.org/license/mit/
 */

--- a/less/variables.less
+++ b/less/variables.less
@@ -1,12 +1,15 @@
 @breakpoint-desktop: 800px;
 
+@font-family-regular: 'Chivo', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+@font-family-titles: 'Cantata One', serif;
+
 @text-color: #3b3b3b;
 @accent-color: #7e00ff;
 @light-color: #fefefe;
 
-@light-color-dark-mode: #3b3b3b;
 @text-color-dark-mode: #efefef;
 @accent-color-dark-mode: #c285ff;
+@light-color-dark-mode: #3b3b3b;
 
 :root {
 	// Typography

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "silver-ratio",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "silver-ratio",
-			"version": "1.4.1",
+			"version": "1.4.2",
 			"license": "ISC",
 			"devDependencies": {
 				"@babel/cli": "7.19.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "silver-ratio",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"description": "A simple WordPress theme.",
 	"main": "gulpfile.js",
 	"scripts": {


### PR DESCRIPTION
Explicitly set `text-decoration-color` for the menu items, so that Safari does not default to a light grey underline color, thus making the menu items consistent with Chromium and Firefox.

Also: A little CSS cleanup to centralize the font-family values in two new less variables (CSS vars don’t seem to work as `font-family`).