### PR TITLE
Use proper underline color for hovering of menu items in footer

### DIFF
--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 <?php if ( is_tag() ) {
 	$tag = get_queried_object();
 	single_tag_title(
-		'<div class="info">' . __( 'Showing posts with the tag ', 'silver-ratio' ) . ' <strong>'
+		'<div class="info">' . __( 'Only showing posts with the tag ', 'silver-ratio' ) . ' <strong>'
 	);
 	echo '</strong>.</a></div>';
 } ?>

--- a/less/footer.less
+++ b/less/footer.less
@@ -34,6 +34,7 @@
 
 				&:hover {
 					text-decoration: underline;
+					text-decoration-color: var(--footer-text-color);
 				}
 			}
 

--- a/less/meta.less
+++ b/less/meta.less
@@ -6,7 +6,7 @@
   Author: Sebastian Herrmann
   Author URI: https://herrherrmann.net
   Tags: two-columns, left-sidebar, custom-menu, custom-header, editor-style
-  Version: 1.4.2
+  Version: 1.4.3
   License: MIT License
   License URI: https://opensource.org/license/mit/
 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "silver-ratio",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "silver-ratio",
-			"version": "1.4.2",
+			"version": "1.4.3",
 			"license": "ISC",
 			"devDependencies": {
 				"@babel/cli": "7.19.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "silver-ratio",
-	"version": "1.4.2",
+	"version": "1.4.3",
 	"description": "A simple WordPress theme.",
 	"main": "gulpfile.js",
 	"scripts": {


### PR DESCRIPTION
Followup fix for #29 that properly overrides the underline color menu items in the footer on hover (to use white instead of the accent color).

Also: Small wording improvement when filtering for tags.